### PR TITLE
Honor the disableFocus flag in onStopPlayback

### DIFF
--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -28,18 +28,17 @@ android {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation('com.google.android.exoplayer:exoplayer:2.13.2') {
+    implementation('com.google.android.exoplayer:exoplayer:2.15.0') {
         exclude group: 'com.android.support'
     }
 
-    // All support libs must use the same version
+    // All support libs must use the same version.
     implementation "androidx.annotation:annotation:1.1.0"
     implementation "androidx.core:core:1.1.0"
     implementation "androidx.media:media:1.1.0"
 
-    implementation('com.google.android.exoplayer:extension-okhttp:2.13.2') {
+    implementation('com.google.android.exoplayer:extension-okhttp:2.15.0') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
     implementation 'com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}'
-
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -13,6 +13,7 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
 import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.PlaybackException;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackParameters;
@@ -255,7 +256,7 @@ public final class ExoPlayerView extends FrameLayout {
         }
 
         @Override
-        public void onPlayerError(ExoPlaybackException e) {
+        public void onPlayerError(PlaybackException e) {
             // Do nothing.
         }
 
@@ -265,7 +266,7 @@ public final class ExoPlayerView extends FrameLayout {
         }
 
         @Override
-        public void onTimelineChanged(Timeline timeline, Object manifest, int reason) {
+        public void onTimelineChanged(Timeline timeline, int reason) {
             // Do nothing.
         }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -148,7 +148,7 @@ class ReactExoplayerView extends FrameLayout implements
     private String textTrackType;
     private Dynamic textTrackValue;
     private ReadableArray textTracks;
-    private boolean disableFocus;
+    private boolean disableFocus = true;
     private boolean preventsDisplaySleepDuringVideoPlayback = true;
     private float mProgressUpdateInterval = 250.0f;
     private boolean playInBackground = false;
@@ -596,7 +596,7 @@ class ReactExoplayerView extends FrameLayout implements
         if (disableFocus || srcUri == null || this.hasAudioFocus) {
             return true;
         }
-        Log.d(TAG, "abandonAudioFocus, instance=" + hashCode());
+        Log.d(TAG, "requestAudioFocus -> audioManager.requestAudioFocus, disableFocus=" + disableFocus + ", instance=" + hashCode());
         int result = audioManager.requestAudioFocus(this,
                 AudioManager.STREAM_MUSIC,
                 AudioManager.AUDIOFOCUS_GAIN);
@@ -607,7 +607,7 @@ class ReactExoplayerView extends FrameLayout implements
         if (disableFocus || srcUri == null || !this.hasAudioFocus) {
             return true;
         }
-        Log.d(TAG, "abandonAudioFocus, instance=" + hashCode());
+        Log.d(TAG, "abandonAudioFocus -> audioManager.abandonAudioFocus, disableFocus=" + disableFocus + ", instance=" + hashCode());
         int result = audioManager.abandonAudioFocus(this);
         return result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
     }
@@ -674,6 +674,8 @@ class ReactExoplayerView extends FrameLayout implements
             setFullscreen(false);
         }
 
+        Log.d(TAG, "onStopPlayback -> abandonAudioFocus, instance=" + hashCode());
+
         if (abandonAudioFocus()) {
             this.hasAudioFocus = false;
         }
@@ -726,6 +728,7 @@ class ReactExoplayerView extends FrameLayout implements
                 this.hasAudioFocus = false;
                 eventEmitter.audioFocusChanged(false);
                 pausePlayback();
+                Log.d(TAG, "onAudioFocusChange(AUDIOFOCUS_LOSS) -> abandonAudioFocus, instance=" + hashCode());
                 abandonAudioFocus();
                 break;
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -397,7 +397,15 @@ class ReactExoplayerView extends FrameLayout implements
         ReactExoplayerView self = this;
 
         if (initializing) {
-            Log.d(TAG, "initializePlayer, skipping initialization, instance=" + hashCode());
+            Log.d(TAG, "initializePlayer, skipping initialization since it's already in progress, instance=" + hashCode());
+            return;
+        }
+
+        boolean initializationRequired =
+          player == null || (playerNeedsSource && srcUri != null);
+
+        if (!initializationRequired) {
+            Log.d(TAG, "initializePlayer, skipping initialization since it's not required, instance=" + hashCode());
             return;
         }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1083,6 +1083,7 @@ class ReactExoplayerView extends FrameLayout implements
                             this.requestHeaders);
 
             if (!isSourceEqual) {
+                Log.d(TAG, 'setSrc -> reloadSource, source changed, instance=' + hashCode());
                 reloadSource();
             }
         }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -205,7 +205,7 @@ class ReactExoplayerView extends FrameLayout implements
         themedReactContext.addLifecycleEventListener(this);
         audioBecomingNoisyReceiver = new AudioBecomingNoisyReceiver(themedReactContext);
 
-        Log.d(TAG, 'createViewInstance -> new ReactExoplayerView(), instance=' + hashCode());
+        Log.d(TAG, "createViewInstance -> new ReactExoplayerView(), instance=" + hashCode());
     }
 
 
@@ -273,7 +273,7 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     public void cleanUpResources() {
-        Log.d(TAG, 'onDropViewInstance -> cleanUpResources, instance=' + hashCode());
+        Log.d(TAG, "onDropViewInstance -> cleanUpResources, instance=" + hashCode());
         stopPlayback();
     }
 
@@ -583,7 +583,7 @@ class ReactExoplayerView extends FrameLayout implements
         if (disableFocus || srcUri == null || this.hasAudioFocus) {
             return true;
         }
-        Log.d(TAG, 'abandonAudioFocus, instance=' + hashCode());
+        Log.d(TAG, "abandonAudioFocus, instance=" + hashCode());
         int result = audioManager.requestAudioFocus(this,
                 AudioManager.STREAM_MUSIC,
                 AudioManager.AUDIOFOCUS_GAIN);
@@ -594,7 +594,7 @@ class ReactExoplayerView extends FrameLayout implements
         if (disableFocus || srcUri == null || !this.hasAudioFocus) {
             return true;
         }
-        Log.d(TAG, 'abandonAudioFocus, instance=' + hashCode());
+        Log.d(TAG, "abandonAudioFocus, instance=" + hashCode());
         int result = audioManager.abandonAudioFocus(this);
         return result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
     }
@@ -740,7 +740,7 @@ class ReactExoplayerView extends FrameLayout implements
             }
         }
 
-        Log.d(TAG, text + ', instance=' + hashCode());
+        Log.d(TAG, text + ", instance=" + hashCode());
     }
 
     // AudioBecomingNoisyListener implementation
@@ -798,7 +798,7 @@ class ReactExoplayerView extends FrameLayout implements
                 break;
         }
 
-        Log.d(TAG, text + ', instance=' + hashCode());
+        Log.d(TAG, text + ", instance=" + hashCode());
     }
 
     private void startProgressHandler() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -394,13 +394,6 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private void initializePlayer() {
-        ReactExoplayerView self = this;
-
-        if (initializing) {
-            Log.d(TAG, "initializePlayer, skipping initialization since it's already in progress, instance=" + hashCode());
-            return;
-        }
-
         boolean initializationRequired =
           player == null || (playerNeedsSource && srcUri != null);
 
@@ -409,102 +402,97 @@ class ReactExoplayerView extends FrameLayout implements
             return;
         }
 
+        if (initializing) {
+            Log.d(TAG, "initializePlayer, skipping initialization since it's already in progress, instance=" + hashCode());
+            return;
+        }
+
         Log.d(TAG, "initializePlayer, enqueuing async initialization, instance=" + hashCode());
         initializing = true;
 
-        // This ensures all props have been settled, to avoid async racing conditions.
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                if (player == null) {
-                    ExoTrackSelection.Factory videoTrackSelectionFactory = new AdaptiveTrackSelection.Factory();
-                    trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
-                    trackSelector.setParameters(trackSelector.buildUponParameters()
-                            .setMaxVideoBitrate(maxBitRate == 0 ? Integer.MAX_VALUE : maxBitRate));
+        if (player == null) {
+            ExoTrackSelection.Factory videoTrackSelectionFactory = new AdaptiveTrackSelection.Factory();
+            trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
+            trackSelector.setParameters(trackSelector.buildUponParameters()
+                .setMaxVideoBitrate(maxBitRate == 0 ? Integer.MAX_VALUE : maxBitRate));
+            DefaultAllocator allocator = new DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE);
+            DefaultLoadControl.Builder defaultLoadControlBuilder = new DefaultLoadControl.Builder();
+            defaultLoadControlBuilder.setAllocator(allocator);
+            defaultLoadControlBuilder.setBufferDurationsMs(minBufferMs, maxBufferMs, bufferForPlaybackMs, bufferForPlaybackAfterRebufferMs);
+            defaultLoadControlBuilder.setTargetBufferBytes(-1);
+            defaultLoadControlBuilder.setPrioritizeTimeOverSizeThresholds(true);
+            DefaultLoadControl defaultLoadControl = defaultLoadControlBuilder.createDefaultLoadControl();
+            DefaultRenderersFactory renderersFactory = new DefaultRenderersFactory(getContext())
+                .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF);
+            player = new SimpleExoPlayer.Builder(getContext(), renderersFactory)
+                .setTrackSelector​(trackSelector)
+                .setBandwidthMeter(bandwidthMeter)
+                .setLoadControl(defaultLoadControl)
+                .build();
+            player.addListener(this);
+            player.addMetadataOutput(this);
+            exoPlayerView.setPlayer(player);
+            audioBecomingNoisyReceiver.setListener(this);
+            bandwidthMeter.addEventListener(new Handler(), this);
+            setPlayWhenReady(!isPaused);
+            playerNeedsSource = true;
+            PlaybackParameters params = new PlaybackParameters(rate, 1f);
+            player.setPlaybackParameters(params);
+            Log.d(TAG, "initializePlayer, creating new SimpleExoPlayer, setting playerNeedsSource to true, instance=" + hashCode());
+        } else {
+            Log.d(TAG, "initializePlayer, *NOT* creating new SimpleExoPlayer, instance=" + hashCode());
+        }
 
-                    DefaultAllocator allocator = new DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE);
-                    DefaultLoadControl.Builder defaultLoadControlBuilder = new DefaultLoadControl.Builder();
-                    defaultLoadControlBuilder.setAllocator(allocator);
-                    defaultLoadControlBuilder.setBufferDurationsMs(minBufferMs, maxBufferMs, bufferForPlaybackMs, bufferForPlaybackAfterRebufferMs);
-                    defaultLoadControlBuilder.setTargetBufferBytes(-1);
-                    defaultLoadControlBuilder.setPrioritizeTimeOverSizeThresholds(true);
-                    DefaultLoadControl defaultLoadControl = defaultLoadControlBuilder.createDefaultLoadControl();
-                    DefaultRenderersFactory renderersFactory =
-                            new DefaultRenderersFactory(getContext())
-                                    .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF);
-                    player = new SimpleExoPlayer.Builder(getContext(), renderersFactory)
-                                .setTrackSelector​(trackSelector)
-                                .setBandwidthMeter(bandwidthMeter)
-                                .setLoadControl(defaultLoadControl)
-                                .build();
-                    player.addListener(self);
-                    player.addMetadataOutput(self);
-                    exoPlayerView.setPlayer(player);
-                    audioBecomingNoisyReceiver.setListener(self);
-                    bandwidthMeter.addEventListener(new Handler(), self);
-                    setPlayWhenReady(!isPaused);
-                    playerNeedsSource = true;
+        if (playerNeedsSource && srcUri != null) {
+            exoPlayerView.invalidateAspectRatio();
 
-                    PlaybackParameters params = new PlaybackParameters(rate, 1f);
-                    player.setPlaybackParameters(params);
-                    Log.d(TAG, "initializePlayer, creating new SimpleExoPlayer, setting playerNeedsSource to true, instance=" + self.hashCode() + ", runnable=" + hashCode());
-                } else {
-                    Log.d(TAG, "initializePlayer, *NOT* creating new SimpleExoPlayer, instance=" + self.hashCode() + ", runnable=" + hashCode());
+            // DRM
+            DrmSessionManager drmSessionManager = null;
+            if (drmUUID != null) {
+                try {
+                    drmSessionManager = buildDrmSessionManager(drmUUID, drmLicenseUrl, drmLicenseHeader);
+                } catch (UnsupportedDrmException e) {
+                    int errorStringId = Util.SDK_INT < 18 ?
+                        R.string.error_drm_not_supported :
+                        (e.reason == UnsupportedDrmException.REASON_UNSUPPORTED_SCHEME ? R.string.error_drm_unsupported_scheme : R.string.error_drm_unknown);
+                    eventEmitter.error(getResources().getString(errorStringId), e);
+                    return;
                 }
-
-                if (playerNeedsSource && srcUri != null) {
-                    exoPlayerView.invalidateAspectRatio();
-
-                    // DRM
-                    DrmSessionManager drmSessionManager = null;
-                    if (self.drmUUID != null) {
-                        try {
-                            drmSessionManager = buildDrmSessionManager(self.drmUUID, self.drmLicenseUrl, self.drmLicenseHeader);
-                        } catch (UnsupportedDrmException e) {
-                            int errorStringId = Util.SDK_INT < 18 ?
-                              R.string.error_drm_not_supported :
-                              (e.reason == UnsupportedDrmException.REASON_UNSUPPORTED_SCHEME ? R.string.error_drm_unsupported_scheme : R.string.error_drm_unknown);
-                            eventEmitter.error(getResources().getString(errorStringId), e);
-                            return;
-                        }
-                    }
-                    // End DRM
-
-                    ArrayList<MediaSource> mediaSourceList = buildTextSources();
-                    MediaSource videoSource = buildMediaSource(srcUri, extension, drmSessionManager);
-                    MediaSource mediaSource;
-
-                    if (mediaSourceList.size() == 0) {
-                        mediaSource = videoSource;
-                    } else {
-                        mediaSourceList.add(0, videoSource);
-                        MediaSource[] textSourceArray = mediaSourceList.toArray(new MediaSource[mediaSourceList.size()]);
-                        mediaSource = new MergingMediaSource(textSourceArray);
-                    }
-
-                    boolean haveResumePosition = resumeWindow != C.INDEX_UNSET;
-                    if (haveResumePosition) {
-                        player.seekTo(resumeWindow, resumePosition);
-                    }
-                    player.prepare(mediaSource, !haveResumePosition, false);
-                    playerNeedsSource = false;
-
-                    reLayout(exoPlayerView);
-                    eventEmitter.loadStart();
-                    loadVideoStarted = true;
-                    Log.d(TAG, "initializePlayer, load source, uri=" + srcUri + ", instance=" + self.hashCode() + ", runnable=" + hashCode());
-                } else {
-                    Log.d(TAG, "initializePlayer, *NOT* loading source, instance=" + self.hashCode() + ", runnable=" + hashCode());
-                }
-
-                // Initializing the playerControlView
-                initializePlayerControl();
-                setControls(controls);
-                applyModifiers();
-
-                initializing = false;
             }
-        }, 1);
+            // End DRM
+
+            ArrayList<MediaSource> mediaSourceList = buildTextSources();
+            MediaSource videoSource = buildMediaSource(srcUri, extension, drmSessionManager);
+            MediaSource mediaSource;
+
+            if (mediaSourceList.size() == 0) {
+                mediaSource = videoSource;
+            } else {
+                mediaSourceList.add(0, videoSource);
+                MediaSource[] textSourceArray = mediaSourceList.toArray(new MediaSource[mediaSourceList.size()]);
+                mediaSource = new MergingMediaSource(textSourceArray);
+            }
+
+            boolean haveResumePosition = resumeWindow != C.INDEX_UNSET;
+            if (haveResumePosition) {
+                player.seekTo(resumeWindow, resumePosition);
+            }
+            player.prepare(mediaSource, !haveResumePosition, false);
+            playerNeedsSource = false;
+
+            reLayout(exoPlayerView);
+            eventEmitter.loadStart();
+            loadVideoStarted = true;
+            Log.d(TAG, "initializePlayer, load source, uri=" + srcUri + ", instance=" + hashCode());
+        } else {
+            Log.d(TAG, "initializePlayer, *NOT* loading source, instance=" + hashCode());
+        }
+
+        initializePlayerControl();
+        setControls(controls);
+        applyModifiers();
+
+        initializing = false;
     }
 
     private DrmSessionManager buildDrmSessionManager(UUID uuid, String licenseUrl, String[] keyRequestPropertiesArray) throws UnsupportedDrmException {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1063,15 +1063,15 @@ class ReactExoplayerView extends FrameLayout implements
     // ReactExoplayerViewManager public api
 
     public void setSrc(final Uri uri, final String extension, Map<String, String> headers) {
+        Log.d(TAG, "setSrc -> " + uri + ", instance=" + hashCode());
+
         if (uri != null) {
             boolean isSourceEqual = uri.equals(srcUri);
 
             this.srcUri = uri;
             this.extension = extension;
             this.requestHeaders = headers;
-            this.mediaDataSourceFactory =
-                    DataSourceUtil.getDefaultDataSourceFactory(this.themedReactContext, bandwidthMeter,
-                            this.requestHeaders);
+            this.mediaDataSourceFactory = DataSourceUtil.getDefaultDataSourceFactory(this.themedReactContext, bandwidthMeter, this.requestHeaders);
 
             if (!isSourceEqual) {
                 Log.d(TAG, "setSrc -> reloadSource, source changed, instance=" + hashCode());
@@ -1281,6 +1281,8 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     public void setPausedModifier(boolean paused) {
+        Log.d(TAG, "setPausedModifier -> " + paused + ", instance=" + hashCode());
+
         isPaused = paused;
         if (player != null) {
             if (!paused) {
@@ -1292,6 +1294,8 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     public void setMutedModifier(boolean muted) {
+        Log.d(TAG, "setMutedModifier -> " + muted + ", instance=" + hashCode());
+
         this.muted = muted;
         audioVolume = muted ? 0.f : 1.f;
         if (player != null) {
@@ -1299,8 +1303,9 @@ class ReactExoplayerView extends FrameLayout implements
         }
     }
 
-
     public void setVolumeModifier(float volume) {
+        Log.d(TAG, "setVolumeModifier -> " + volume + ", instance=" + hashCode());
+
         audioVolume = volume;
         if (player != null) {
             player.setVolume(audioVolume);
@@ -1327,7 +1332,7 @@ class ReactExoplayerView extends FrameLayout implements
         maxBitRate = newMaxBitRate;
         if (player != null) {
             trackSelector.setParameters(trackSelector.buildUponParameters()
-                    .setMaxVideoBitrate(maxBitRate == 0 ? Integer.MAX_VALUE : maxBitRate));
+                .setMaxVideoBitrate(maxBitRate == 0 ? Integer.MAX_VALUE : maxBitRate));
         }
     }
 
@@ -1343,6 +1348,7 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     public void setDisableFocus(boolean disableFocus) {
+        Log.d(TAG, "setDisableFocus -> " + disableFocus + ", instance=" + hashCode());
         this.disableFocus = disableFocus;
     }
 
@@ -1409,7 +1415,6 @@ class ReactExoplayerView extends FrameLayout implements
     public void setDrmLicenseHeader(String[] header){
         this.drmLicenseHeader = header;
     }
-
 
     @Override
     public void onDrmKeysLoaded(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -431,9 +431,9 @@ class ReactExoplayerView extends FrameLayout implements
 
                     PlaybackParameters params = new PlaybackParameters(rate, 1f);
                     player.setPlaybackParameters(params);
-                    Log.d(TAG, "initializePlayer, creating new SimpleExoPlayer, instance=" + self.hashCode());
+                    Log.d(TAG, "initializePlayer, creating new SimpleExoPlayer, setting playerNeedsSource to true, instance=" + self.hashCode() + ", runnable=" + hashCode());
                 } else {
-                    Log.d(TAG, "initializePlayer, *NOT* creating new SimpleExoPlayer, instance=" + self.hashCode());
+                    Log.d(TAG, "initializePlayer, *NOT* creating new SimpleExoPlayer, instance=" + self.hashCode() + ", runnable=" + hashCode());
                 }
 
                 if (playerNeedsSource && srcUri != null) {
@@ -443,12 +443,11 @@ class ReactExoplayerView extends FrameLayout implements
                     DrmSessionManager drmSessionManager = null;
                     if (self.drmUUID != null) {
                         try {
-                            drmSessionManager = buildDrmSessionManager(self.drmUUID, self.drmLicenseUrl,
-                                    self.drmLicenseHeader);
+                            drmSessionManager = buildDrmSessionManager(self.drmUUID, self.drmLicenseUrl, self.drmLicenseHeader);
                         } catch (UnsupportedDrmException e) {
-                            int errorStringId = Util.SDK_INT < 18 ? R.string.error_drm_not_supported
-                                    : (e.reason == UnsupportedDrmException.REASON_UNSUPPORTED_SCHEME
-                                    ? R.string.error_drm_unsupported_scheme : R.string.error_drm_unknown);
+                            int errorStringId = Util.SDK_INT < 18 ?
+                              R.string.error_drm_not_supported :
+                              (e.reason == UnsupportedDrmException.REASON_UNSUPPORTED_SCHEME ? R.string.error_drm_unsupported_scheme : R.string.error_drm_unknown);
                             eventEmitter.error(getResources().getString(errorStringId), e);
                             return;
                         }
@@ -458,13 +457,12 @@ class ReactExoplayerView extends FrameLayout implements
                     ArrayList<MediaSource> mediaSourceList = buildTextSources();
                     MediaSource videoSource = buildMediaSource(srcUri, extension, drmSessionManager);
                     MediaSource mediaSource;
+
                     if (mediaSourceList.size() == 0) {
                         mediaSource = videoSource;
                     } else {
                         mediaSourceList.add(0, videoSource);
-                        MediaSource[] textSourceArray = mediaSourceList.toArray(
-                                new MediaSource[mediaSourceList.size()]
-                        );
+                        MediaSource[] textSourceArray = mediaSourceList.toArray(new MediaSource[mediaSourceList.size()]);
                         mediaSource = new MergingMediaSource(textSourceArray);
                     }
 
@@ -478,9 +476,9 @@ class ReactExoplayerView extends FrameLayout implements
                     reLayout(exoPlayerView);
                     eventEmitter.loadStart();
                     loadVideoStarted = true;
-                    Log.d(TAG, "initializePlayer, loading sourch, instance=" + self.hashCode());
+                    Log.d(TAG, "initializePlayer, load source, uri=" + srcUri + ", instance=" + self.hashCode() + ", runnable=" + hashCode());
                 } else {
-                    Log.d(TAG, "initializePlayer, *NOT* loading source, instance=" + self.hashCode());
+                    Log.d(TAG, "initializePlayer, *NOT* loading source, instance=" + self.hashCode() + ", runnable=" + hashCode());
                 }
 
                 // Initializing the playerControlView
@@ -1009,7 +1007,7 @@ class ReactExoplayerView extends FrameLayout implements
 
         eventEmitter.error(errorString, ex);
         playerNeedsSource = true;
-        Log.d(TAG, "onPlayerError -> initializePlayer, error= " + errorString + ", instance=" + hashCode());
+        Log.d(TAG, "onPlayerError -> initializePlayer, setting playerNeedsSource to true, error= " + errorString + ", instance=" + hashCode());
 
         if (isBehindLiveWindow(e)) {
             clearResumePosition();
@@ -1112,7 +1110,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     private void reloadSource() {
         playerNeedsSource = true;
-        Log.d(TAG, "onPlayerError -> initializePlayer, instance=" + hashCode());
+        Log.d(TAG, "reloadSource -> initializePlayer, setting playerNeedsSource to true, instance=" + hashCode());
         initializePlayer();
     }
 
@@ -1326,7 +1324,7 @@ class ReactExoplayerView extends FrameLayout implements
     public void setMinLoadRetryCountModifier(int newMinLoadRetryCount) {
         minLoadRetryCount = newMinLoadRetryCount;
         releasePlayer();
-        Log.d(TAG, "onPlayerError -> initializePlayer, instance=" + hashCode());
+        Log.d(TAG, "setMinLoadRetryCountModifier -> initializePlayer, instance=" + hashCode());
         initializePlayer();
     }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -393,7 +393,9 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private void initializePlayer() {
+        Log.d(TAG, "initializePlayer, enqueuing async initialization, instance=" + hashCode());
         ReactExoplayerView self = this;
+
         // This ensures all props have been settled, to avoid async racing conditions.
         new Handler().postDelayed(new Runnable() {
             @Override
@@ -429,9 +431,9 @@ class ReactExoplayerView extends FrameLayout implements
 
                     PlaybackParameters params = new PlaybackParameters(rate, 1f);
                     player.setPlaybackParameters(params);
-                    Log.d(TAG, "initializePlayer, creating new SimpleExoPlayer, instance=" + hashCode());
+                    Log.d(TAG, "initializePlayer, creating new SimpleExoPlayer, instance=" + self.hashCode());
                 } else {
-                    Log.d(TAG, "initializePlayer, *NOT* creating new SimpleExoPlayer, instance=" + hashCode());
+                    Log.d(TAG, "initializePlayer, *NOT* creating new SimpleExoPlayer, instance=" + self.hashCode());
                 }
 
                 if (playerNeedsSource && srcUri != null) {
@@ -476,9 +478,9 @@ class ReactExoplayerView extends FrameLayout implements
                     reLayout(exoPlayerView);
                     eventEmitter.loadStart();
                     loadVideoStarted = true;
-                    Log.d(TAG, "initializePlayer, loading sourch, instance=" + hashCode());
+                    Log.d(TAG, "initializePlayer, loading sourch, instance=" + self.hashCode());
                 } else {
-                    Log.d(TAG, "initializePlayer, *NOT* loading source, instance=" + hashCode());
+                    Log.d(TAG, "initializePlayer, *NOT* loading source, instance=" + self.hashCode());
                 }
 
                 // Initializing the playerControlView
@@ -1004,8 +1006,11 @@ class ReactExoplayerView extends FrameLayout implements
         else if (e.type == ExoPlaybackException.TYPE_SOURCE) {
             errorString = getResources().getString(R.string.unrecognized_media_format);
         }
+
         eventEmitter.error(errorString, ex);
         playerNeedsSource = true;
+        Log.d(TAG, "onPlayerError -> initializePlayer, error= " + errorString + ", instance=" + hashCode());
+
         if (isBehindLiveWindow(e)) {
             clearResumePosition();
             Log.d(TAG, "onPlayerError -> initializePlayer, instance=" + hashCode());

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -205,8 +205,6 @@ class ReactExoplayerView extends FrameLayout implements
         audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         themedReactContext.addLifecycleEventListener(this);
         audioBecomingNoisyReceiver = new AudioBecomingNoisyReceiver(themedReactContext);
-
-        Log.d(TAG, "createViewInstance -> new ReactExoplayerView(), instance=" + hashCode());
     }
 
 
@@ -237,7 +235,6 @@ class ReactExoplayerView extends FrameLayout implements
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        Log.d(TAG, "onAttachedToWindow -> initializePlayer, instance=" + hashCode());
         initializePlayer();
     }
 
@@ -275,7 +272,6 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     public void cleanUpResources() {
-        Log.d(TAG, "onDropViewInstance -> cleanUpResources, instance=" + hashCode());
         stopPlayback();
     }
 
@@ -398,16 +394,13 @@ class ReactExoplayerView extends FrameLayout implements
           player == null || (playerNeedsSource && srcUri != null);
 
         if (!initializationRequired) {
-            Log.d(TAG, "initializePlayer, skipping initialization since it's not required, instance=" + hashCode());
             return;
         }
 
         if (initializing) {
-            Log.d(TAG, "initializePlayer, skipping initialization since it's already in progress, instance=" + hashCode());
             return;
         }
 
-        Log.d(TAG, "initializePlayer, enqueuing async initialization, instance=" + hashCode());
         initializing = true;
 
         if (player == null) {
@@ -438,9 +431,6 @@ class ReactExoplayerView extends FrameLayout implements
             playerNeedsSource = true;
             PlaybackParameters params = new PlaybackParameters(rate, 1f);
             player.setPlaybackParameters(params);
-            Log.d(TAG, "initializePlayer, creating new SimpleExoPlayer, setting playerNeedsSource to true, instance=" + hashCode());
-        } else {
-            Log.d(TAG, "initializePlayer, *NOT* creating new SimpleExoPlayer, instance=" + hashCode());
         }
 
         if (playerNeedsSource && srcUri != null) {
@@ -473,15 +463,12 @@ class ReactExoplayerView extends FrameLayout implements
                 mediaSource = new MergingMediaSource(textSourceArray);
             }
 
-            Log.d(TAG, "initializePlayer, load source, uri=" + srcUri + ", instance=" + hashCode());
             player.prepare(mediaSource);
             playerNeedsSource = false;
 
             reLayout(exoPlayerView);
             eventEmitter.loadStart();
             loadVideoStarted = true;
-        } else {
-            Log.d(TAG, "initializePlayer, *NOT* loading source, instance=" + hashCode());
         }
 
         initializePlayerControl();
@@ -598,7 +585,6 @@ class ReactExoplayerView extends FrameLayout implements
         if (disableFocus || srcUri == null || this.hasAudioFocus) {
             return true;
         }
-        Log.d(TAG, "requestAudioFocus -> audioManager.requestAudioFocus, disableFocus=" + disableFocus + ", instance=" + hashCode());
         int result = audioManager.requestAudioFocus(this,
                 AudioManager.STREAM_MUSIC,
                 AudioManager.AUDIOFOCUS_GAIN);
@@ -609,7 +595,6 @@ class ReactExoplayerView extends FrameLayout implements
         if (disableFocus || srcUri == null || !this.hasAudioFocus) {
             return true;
         }
-        Log.d(TAG, "abandonAudioFocus -> audioManager.abandonAudioFocus, disableFocus=" + disableFocus + ", instance=" + hashCode());
         int result = audioManager.abandonAudioFocus(this);
         return result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
     }
@@ -634,7 +619,6 @@ class ReactExoplayerView extends FrameLayout implements
             switch (player.getPlaybackState()) {
                 case Player.STATE_IDLE:
                 case Player.STATE_ENDED:
-                    Log.d(TAG, "startPlayback -> initializePlayer, player already instantiated, instance=" + hashCode());
                     initializePlayer();
                     break;
                 case Player.STATE_BUFFERING:
@@ -648,7 +632,6 @@ class ReactExoplayerView extends FrameLayout implements
             }
 
         } else {
-            Log.d(TAG, "startPlayback -> initializePlayer, player not already instantiated, instance=" + hashCode());
             initializePlayer();
         }
 
@@ -675,8 +658,6 @@ class ReactExoplayerView extends FrameLayout implements
         if (isFullscreen) {
             setFullscreen(false);
         }
-
-        Log.d(TAG, "onStopPlayback -> abandonAudioFocus, instance=" + hashCode());
 
         if (abandonAudioFocus()) {
             this.hasAudioFocus = false;
@@ -722,28 +703,21 @@ class ReactExoplayerView extends FrameLayout implements
 
     @Override
     public void onAudioFocusChange(int focusChange) {
-        String text = "onAudioFocusChange: focusChange=";
-
         switch (focusChange) {
             case AudioManager.AUDIOFOCUS_LOSS:
-                text += "loss";
                 this.hasAudioFocus = false;
                 eventEmitter.audioFocusChanged(false);
                 pausePlayback();
-                Log.d(TAG, "onAudioFocusChange(AUDIOFOCUS_LOSS) -> abandonAudioFocus, instance=" + hashCode());
                 abandonAudioFocus();
                 break;
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
-                text += "loss_transient";
                 eventEmitter.audioFocusChanged(false);
                 break;
             case AudioManager.AUDIOFOCUS_GAIN:
-                text += "gain";
                 this.hasAudioFocus = true;
                 eventEmitter.audioFocusChanged(true);
                 break;
             default:
-                text += "unknown";
                 break;
         }
 
@@ -760,8 +734,6 @@ class ReactExoplayerView extends FrameLayout implements
                 }
             }
         }
-
-        Log.d(TAG, text + ", instance=" + hashCode());
     }
 
     // AudioBecomingNoisyListener implementation
@@ -819,7 +791,7 @@ class ReactExoplayerView extends FrameLayout implements
                 break;
         }
 
-        Log.d(TAG, text + ", instance=" + hashCode());
+        Log.d(TAG, text);
     }
 
     private void startProgressHandler() {
@@ -836,8 +808,6 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private void videoLoaded() {
-        Log.d(TAG, "videoLoaded, instance=" + hashCode());
-
         if (loadVideoStarted) {
             loadVideoStarted = false;
             setSelectedAudioTrack(audioTrackType, audioTrackValue);
@@ -1026,11 +996,9 @@ class ReactExoplayerView extends FrameLayout implements
 
         eventEmitter.error(errorString, ex);
         playerNeedsSource = true;
-        Log.d(TAG, "onPlayerError -> initializePlayer, setting playerNeedsSource to true, error= " + errorString + ", instance=" + hashCode());
 
         if (isBehindLiveWindow(e)) {
             clearResumePosition();
-            Log.d(TAG, "onPlayerError -> initializePlayer, instance=" + hashCode());
             initializePlayer();
         } else {
             updateResumePosition();
@@ -1073,8 +1041,6 @@ class ReactExoplayerView extends FrameLayout implements
     // ReactExoplayerViewManager public api
 
     public void setSrc(final Uri uri, final String extension, Map<String, String> headers) {
-        Log.d(TAG, "setSrc -> " + uri + ", instance=" + hashCode());
-
         if (uri != null) {
             boolean isSourceEqual = uri.equals(srcUri);
 
@@ -1084,7 +1050,6 @@ class ReactExoplayerView extends FrameLayout implements
             this.mediaDataSourceFactory = DataSourceUtil.getDefaultDataSourceFactory(this.themedReactContext, bandwidthMeter, this.requestHeaders);
 
             if (!isSourceEqual) {
-                Log.d(TAG, "setSrc -> reloadSource, source changed, instance=" + hashCode());
                 reloadSource();
             }
         }
@@ -1130,7 +1095,6 @@ class ReactExoplayerView extends FrameLayout implements
 
     private void reloadSource() {
         playerNeedsSource = true;
-        Log.d(TAG, "reloadSource -> initializePlayer, setting playerNeedsSource to true, instance=" + hashCode());
         initializePlayer();
     }
 
@@ -1291,8 +1255,6 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     public void setPausedModifier(boolean paused) {
-        Log.d(TAG, "setPausedModifier -> " + paused + ", instance=" + hashCode());
-
         isPaused = paused;
         if (player != null) {
             if (!paused) {
@@ -1304,8 +1266,6 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     public void setMutedModifier(boolean muted) {
-        Log.d(TAG, "setMutedModifier -> " + muted + ", instance=" + hashCode());
-
         this.muted = muted;
         audioVolume = muted ? 0.f : 1.f;
         if (player != null) {
@@ -1314,8 +1274,6 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     public void setVolumeModifier(float volume) {
-        Log.d(TAG, "setVolumeModifier -> " + volume + ", instance=" + hashCode());
-
         audioVolume = volume;
         if (player != null) {
             player.setVolume(audioVolume);
@@ -1349,7 +1307,6 @@ class ReactExoplayerView extends FrameLayout implements
     public void setMinLoadRetryCountModifier(int newMinLoadRetryCount) {
         minLoadRetryCount = newMinLoadRetryCount;
         releasePlayer();
-        Log.d(TAG, "setMinLoadRetryCountModifier -> initializePlayer, instance=" + hashCode());
         initializePlayer();
     }
 
@@ -1358,7 +1315,6 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     public void setDisableFocus(boolean disableFocus) {
-        Log.d(TAG, "setDisableFocus -> " + disableFocus + ", instance=" + hashCode());
         this.disableFocus = disableFocus;
     }
 
@@ -1410,7 +1366,6 @@ class ReactExoplayerView extends FrameLayout implements
         bufferForPlaybackMs = newBufferForPlaybackMs;
         bufferForPlaybackAfterRebufferMs = newBufferForPlaybackAfterRebufferMs;
         releasePlayer();
-        Log.d(TAG, "setBufferConfig -> initializePlayer, instance=" + hashCode());
         initializePlayer();
     }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -473,17 +473,13 @@ class ReactExoplayerView extends FrameLayout implements
                 mediaSource = new MergingMediaSource(textSourceArray);
             }
 
-            boolean haveResumePosition = resumeWindow != C.INDEX_UNSET;
-            if (haveResumePosition) {
-                player.seekTo(resumeWindow, resumePosition);
-            }
-            player.prepare(mediaSource, !haveResumePosition, false);
+            Log.d(TAG, "initializePlayer, load source, uri=" + srcUri + ", instance=" + hashCode());
+            player.prepare(mediaSource);
             playerNeedsSource = false;
 
             reLayout(exoPlayerView);
             eventEmitter.loadStart();
             loadVideoStarted = true;
-            Log.d(TAG, "initializePlayer, load source, uri=" + srcUri + ", instance=" + hashCode());
         } else {
             Log.d(TAG, "initializePlayer, *NOT* loading source, instance=" + hashCode());
         }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1383,23 +1383,23 @@ class ReactExoplayerView extends FrameLayout implements
 
     @Override
     public void onDrmKeysLoaded(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
-        // Log.d("DRM Info", "onDrmKeysLoaded");
+        Log.d("DRM Info", "onDrmKeysLoaded");
     }
 
     @Override
     public void onDrmSessionManagerError(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId, Exception e) {
-        // Log.d("DRM Info", "onDrmSessionManagerError");
+        Log.d("DRM Info", "onDrmSessionManagerError");
         eventEmitter.error("onDrmSessionManagerError", e);
     }
 
     @Override
     public void onDrmKeysRestored(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
-        // Log.d("DRM Info", "onDrmKeysRestored");
+        Log.d("DRM Info", "onDrmKeysRestored");
     }
 
     @Override
     public void onDrmKeysRemoved(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
-        // Log.d("DRM Info", "onDrmKeysRemoved");
+        Log.d("DRM Info", "onDrmKeysRemoved");
     }
 
     /**

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1083,7 +1083,7 @@ class ReactExoplayerView extends FrameLayout implements
                             this.requestHeaders);
 
             if (!isSourceEqual) {
-                Log.d(TAG, 'setSrc -> reloadSource, source changed, instance=' + hashCode());
+                Log.d(TAG, "setSrc -> reloadSource, source changed, instance=" + hashCode());
                 reloadSource();
             }
         }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -113,7 +113,6 @@ class ReactExoplayerView extends FrameLayout implements
     private SimpleExoPlayer player;
     private DefaultTrackSelector trackSelector;
     private boolean playerNeedsSource;
-    private boolean initializing;
 
     private int resumeWindow;
     private long resumePosition;
@@ -390,92 +389,93 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private void initializePlayer() {
-        boolean initializationRequired =
-          player == null || (playerNeedsSource && srcUri != null);
+        ReactExoplayerView self = this;
+        // This ensures all props have been settled, to avoid async racing conditions.
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                if (player == null) {
+                    ExoTrackSelection.Factory videoTrackSelectionFactory = new AdaptiveTrackSelection.Factory();
+                    trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
+                    trackSelector.setParameters(trackSelector.buildUponParameters()
+                            .setMaxVideoBitrate(maxBitRate == 0 ? Integer.MAX_VALUE : maxBitRate));
 
-        if (!initializationRequired) {
-            return;
-        }
+                    DefaultAllocator allocator = new DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE);
+                    DefaultLoadControl.Builder defaultLoadControlBuilder = new DefaultLoadControl.Builder();
+                    defaultLoadControlBuilder.setAllocator(allocator);
+                    defaultLoadControlBuilder.setBufferDurationsMs(minBufferMs, maxBufferMs, bufferForPlaybackMs, bufferForPlaybackAfterRebufferMs);
+                    defaultLoadControlBuilder.setTargetBufferBytes(-1);
+                    defaultLoadControlBuilder.setPrioritizeTimeOverSizeThresholds(true);
+                    DefaultLoadControl defaultLoadControl = defaultLoadControlBuilder.createDefaultLoadControl();
+                    DefaultRenderersFactory renderersFactory =
+                            new DefaultRenderersFactory(getContext())
+                                    .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF);
+                    player = new SimpleExoPlayer.Builder(getContext(), renderersFactory)
+                                .setTrackSelector​(trackSelector)
+                                .setBandwidthMeter(bandwidthMeter)
+                                .setLoadControl(defaultLoadControl)
+                                .build();
+                    player.addListener(self);
+                    player.addMetadataOutput(self);
+                    exoPlayerView.setPlayer(player);
+                    audioBecomingNoisyReceiver.setListener(self);
+                    bandwidthMeter.addEventListener(new Handler(), self);
+                    setPlayWhenReady(!isPaused);
+                    playerNeedsSource = true;
 
-        if (initializing) {
-            return;
-        }
-
-        initializing = true;
-
-        if (player == null) {
-            ExoTrackSelection.Factory videoTrackSelectionFactory = new AdaptiveTrackSelection.Factory();
-            trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
-            trackSelector.setParameters(trackSelector.buildUponParameters()
-                .setMaxVideoBitrate(maxBitRate == 0 ? Integer.MAX_VALUE : maxBitRate));
-            DefaultAllocator allocator = new DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE);
-            DefaultLoadControl.Builder defaultLoadControlBuilder = new DefaultLoadControl.Builder();
-            defaultLoadControlBuilder.setAllocator(allocator);
-            defaultLoadControlBuilder.setBufferDurationsMs(minBufferMs, maxBufferMs, bufferForPlaybackMs, bufferForPlaybackAfterRebufferMs);
-            defaultLoadControlBuilder.setTargetBufferBytes(-1);
-            defaultLoadControlBuilder.setPrioritizeTimeOverSizeThresholds(true);
-            DefaultLoadControl defaultLoadControl = defaultLoadControlBuilder.createDefaultLoadControl();
-            DefaultRenderersFactory renderersFactory = new DefaultRenderersFactory(getContext())
-                .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF);
-            player = new SimpleExoPlayer.Builder(getContext(), renderersFactory)
-                .setTrackSelector​(trackSelector)
-                .setBandwidthMeter(bandwidthMeter)
-                .setLoadControl(defaultLoadControl)
-                .build();
-            player.addListener(this);
-            player.addMetadataOutput(this);
-            exoPlayerView.setPlayer(player);
-            audioBecomingNoisyReceiver.setListener(this);
-            bandwidthMeter.addEventListener(new Handler(), this);
-            setPlayWhenReady(!isPaused);
-            playerNeedsSource = true;
-            PlaybackParameters params = new PlaybackParameters(rate, 1f);
-            player.setPlaybackParameters(params);
-        }
-
-        if (playerNeedsSource && srcUri != null) {
-            exoPlayerView.invalidateAspectRatio();
-
-            // DRM
-            DrmSessionManager drmSessionManager = null;
-            if (drmUUID != null) {
-                try {
-                    drmSessionManager = buildDrmSessionManager(drmUUID, drmLicenseUrl, drmLicenseHeader);
-                } catch (UnsupportedDrmException e) {
-                    int errorStringId = Util.SDK_INT < 18 ?
-                        R.string.error_drm_not_supported :
-                        (e.reason == UnsupportedDrmException.REASON_UNSUPPORTED_SCHEME ? R.string.error_drm_unsupported_scheme : R.string.error_drm_unknown);
-                    eventEmitter.error(getResources().getString(errorStringId), e);
-                    return;
+                    PlaybackParameters params = new PlaybackParameters(rate, 1f);
+                    player.setPlaybackParameters(params);
                 }
+                if (playerNeedsSource && srcUri != null) {
+                    exoPlayerView.invalidateAspectRatio();
+
+                    // DRM
+                    DrmSessionManager drmSessionManager = null;
+                    if (self.drmUUID != null) {
+                        try {
+                            drmSessionManager = buildDrmSessionManager(self.drmUUID, self.drmLicenseUrl,
+                                    self.drmLicenseHeader);
+                        } catch (UnsupportedDrmException e) {
+                            int errorStringId = Util.SDK_INT < 18 ? R.string.error_drm_not_supported
+                                    : (e.reason == UnsupportedDrmException.REASON_UNSUPPORTED_SCHEME
+                                    ? R.string.error_drm_unsupported_scheme : R.string.error_drm_unknown);
+                            eventEmitter.error(getResources().getString(errorStringId), e);
+                            return;
+                        }
+                    }
+                    // End DRM
+
+                    ArrayList<MediaSource> mediaSourceList = buildTextSources();
+                    MediaSource videoSource = buildMediaSource(srcUri, extension, drmSessionManager);
+                    MediaSource mediaSource;
+                    if (mediaSourceList.size() == 0) {
+                        mediaSource = videoSource;
+                    } else {
+                        mediaSourceList.add(0, videoSource);
+                        MediaSource[] textSourceArray = mediaSourceList.toArray(
+                                new MediaSource[mediaSourceList.size()]
+                        );
+                        mediaSource = new MergingMediaSource(textSourceArray);
+                    }
+
+                    boolean haveResumePosition = resumeWindow != C.INDEX_UNSET;
+                    if (haveResumePosition) {
+                        player.seekTo(resumeWindow, resumePosition);
+                    }
+                    player.prepare(mediaSource, !haveResumePosition, false);
+                    playerNeedsSource = false;
+
+                    reLayout(exoPlayerView);
+                    eventEmitter.loadStart();
+                    loadVideoStarted = true;
+                }
+
+                // Initializing the playerControlView
+                initializePlayerControl();
+                setControls(controls);
+                applyModifiers();
             }
-            // End DRM
-
-            ArrayList<MediaSource> mediaSourceList = buildTextSources();
-            MediaSource videoSource = buildMediaSource(srcUri, extension, drmSessionManager);
-            MediaSource mediaSource;
-
-            if (mediaSourceList.size() == 0) {
-                mediaSource = videoSource;
-            } else {
-                mediaSourceList.add(0, videoSource);
-                MediaSource[] textSourceArray = mediaSourceList.toArray(new MediaSource[mediaSourceList.size()]);
-                mediaSource = new MergingMediaSource(textSourceArray);
-            }
-
-            player.prepare(mediaSource);
-            playerNeedsSource = false;
-
-            reLayout(exoPlayerView);
-            eventEmitter.loadStart();
-            loadVideoStarted = true;
-        }
-
-        initializePlayerControl();
-        setControls(controls);
-        applyModifiers();
-
-        initializing = false;
+        }, 1);
     }
 
     private DrmSessionManager buildDrmSessionManager(UUID uuid, String licenseUrl, String[] keyRequestPropertiesArray) throws UnsupportedDrmException {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -113,6 +113,7 @@ class ReactExoplayerView extends FrameLayout implements
     private SimpleExoPlayer player;
     private DefaultTrackSelector trackSelector;
     private boolean playerNeedsSource;
+    private boolean initializing;
 
     private int resumeWindow;
     private long resumePosition;
@@ -393,8 +394,15 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private void initializePlayer() {
-        Log.d(TAG, "initializePlayer, enqueuing async initialization, instance=" + hashCode());
         ReactExoplayerView self = this;
+
+        if (initializing) {
+            Log.d(TAG, "initializePlayer, skipping initialization, instance=" + hashCode());
+            return;
+        }
+
+        Log.d(TAG, "initializePlayer, enqueuing async initialization, instance=" + hashCode());
+        initializing = true;
 
         // This ensures all props have been settled, to avoid async racing conditions.
         new Handler().postDelayed(new Runnable() {
@@ -485,6 +493,8 @@ class ReactExoplayerView extends FrameLayout implements
                 initializePlayerControl();
                 setControls(controls);
                 applyModifiers();
+
+                initializing = false;
             }
         }, 1);
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -989,14 +989,14 @@ class ReactExoplayerView extends FrameLayout implements
     @Override
     public void onPlayerError(PlaybackException pe) {
         if (!(pe instanceof ExoPlaybackException)) {
-            eventEmitter.error("PlaybackException type : " + e.getErrorCodeName(), pe);
+            eventEmitter.error("PlaybackException type : " + pe.getErrorCodeName(), pe);
             playerNeedsSource = true;
             updateResumePosition();
             return;
         }
 
         ExoPlaybackException e = (ExoPlaybackException) pe;
-        errorString = "ExoPlaybackException type : " + e.type;
+        String errorString = "ExoPlaybackException type : " + e.type;
         Exception ex = e;
         if (e.type == ExoPlaybackException.TYPE_RENDERER) {
             Exception cause = e.getRendererException();

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -236,6 +236,7 @@ class ReactExoplayerView extends FrameLayout implements
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
+        Log.d(TAG, "onAttachedToWindow -> initializePlayer, instance=" + hashCode());
         initializePlayer();
     }
 
@@ -428,7 +429,11 @@ class ReactExoplayerView extends FrameLayout implements
 
                     PlaybackParameters params = new PlaybackParameters(rate, 1f);
                     player.setPlaybackParameters(params);
+                    Log.d(TAG, "initializePlayer, creating new SimpleExoPlayer, instance=" + hashCode());
+                } else {
+                    Log.d(TAG, "initializePlayer, *NOT* creating new SimpleExoPlayer, instance=" + hashCode());
                 }
+
                 if (playerNeedsSource && srcUri != null) {
                     exoPlayerView.invalidateAspectRatio();
 
@@ -471,6 +476,9 @@ class ReactExoplayerView extends FrameLayout implements
                     reLayout(exoPlayerView);
                     eventEmitter.loadStart();
                     loadVideoStarted = true;
+                    Log.d(TAG, "initializePlayer, loading sourch, instance=" + hashCode());
+                } else {
+                    Log.d(TAG, "initializePlayer, *NOT* loading source, instance=" + hashCode());
                 }
 
                 // Initializing the playerControlView
@@ -481,8 +489,7 @@ class ReactExoplayerView extends FrameLayout implements
         }, 1);
     }
 
-    private DrmSessionManager buildDrmSessionManager(UUID uuid,
-                                                                           String licenseUrl, String[] keyRequestPropertiesArray) throws UnsupportedDrmException {
+    private DrmSessionManager buildDrmSessionManager(UUID uuid, String licenseUrl, String[] keyRequestPropertiesArray) throws UnsupportedDrmException {
         if (Util.SDK_INT < 18) {
             return null;
         }
@@ -619,6 +626,7 @@ class ReactExoplayerView extends FrameLayout implements
             switch (player.getPlaybackState()) {
                 case Player.STATE_IDLE:
                 case Player.STATE_ENDED:
+                    Log.d(TAG, "startPlayback -> initializePlayer, player already instantiated, instance=" + hashCode());
                     initializePlayer();
                     break;
                 case Player.STATE_BUFFERING:
@@ -632,8 +640,10 @@ class ReactExoplayerView extends FrameLayout implements
             }
 
         } else {
+            Log.d(TAG, "startPlayback -> initializePlayer, player not already instantiated, instance=" + hashCode());
             initializePlayer();
         }
+
         if (!disableFocus) {
             setKeepScreenOn(preventsDisplaySleepDuringVideoPlayback);
         }
@@ -815,6 +825,8 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private void videoLoaded() {
+        Log.d(TAG, "videoLoaded, instance=" + hashCode());
+
         if (loadVideoStarted) {
             loadVideoStarted = false;
             setSelectedAudioTrack(audioTrackType, audioTrackValue);
@@ -852,6 +864,7 @@ class ReactExoplayerView extends FrameLayout implements
         }
         return audioTracks;
     }
+
     private WritableArray getVideoTrackInfo() {
         WritableArray videoTracks = Arguments.createArray();
 
@@ -995,6 +1008,7 @@ class ReactExoplayerView extends FrameLayout implements
         playerNeedsSource = true;
         if (isBehindLiveWindow(e)) {
             clearResumePosition();
+            Log.d(TAG, "onPlayerError -> initializePlayer, instance=" + hashCode());
             initializePlayer();
         } else {
             updateResumePosition();
@@ -1093,6 +1107,7 @@ class ReactExoplayerView extends FrameLayout implements
 
     private void reloadSource() {
         playerNeedsSource = true;
+        Log.d(TAG, "onPlayerError -> initializePlayer, instance=" + hashCode());
         initializePlayer();
     }
 
@@ -1306,6 +1321,7 @@ class ReactExoplayerView extends FrameLayout implements
     public void setMinLoadRetryCountModifier(int newMinLoadRetryCount) {
         minLoadRetryCount = newMinLoadRetryCount;
         releasePlayer();
+        Log.d(TAG, "onPlayerError -> initializePlayer, instance=" + hashCode());
         initializePlayer();
     }
 
@@ -1365,6 +1381,7 @@ class ReactExoplayerView extends FrameLayout implements
         bufferForPlaybackMs = newBufferForPlaybackMs;
         bufferForPlaybackAfterRebufferMs = newBufferForPlaybackAfterRebufferMs;
         releasePlayer();
+        Log.d(TAG, "setBufferConfig -> initializePlayer, instance=" + hashCode());
         initializePlayer();
     }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -204,6 +204,8 @@ class ReactExoplayerView extends FrameLayout implements
         audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         themedReactContext.addLifecycleEventListener(this);
         audioBecomingNoisyReceiver = new AudioBecomingNoisyReceiver(themedReactContext);
+
+        Log.d(TAG, 'createViewInstance -> new ReactExoplayerView(), instance=' + hashCode());
     }
 
 
@@ -271,6 +273,7 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     public void cleanUpResources() {
+        Log.d(TAG, 'onDropViewInstance -> cleanUpResources, instance=' + hashCode());
         stopPlayback();
     }
 
@@ -580,6 +583,7 @@ class ReactExoplayerView extends FrameLayout implements
         if (disableFocus || srcUri == null || this.hasAudioFocus) {
             return true;
         }
+        Log.d(TAG, 'abandonAudioFocus, instance=' + hashCode());
         int result = audioManager.requestAudioFocus(this,
                 AudioManager.STREAM_MUSIC,
                 AudioManager.AUDIOFOCUS_GAIN);
@@ -590,6 +594,7 @@ class ReactExoplayerView extends FrameLayout implements
         if (disableFocus || srcUri == null || !this.hasAudioFocus) {
             return true;
         }
+        Log.d(TAG, 'abandonAudioFocus, instance=' + hashCode());
         int result = audioManager.abandonAudioFocus(this);
         return result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
     }
@@ -652,7 +657,10 @@ class ReactExoplayerView extends FrameLayout implements
         if (isFullscreen) {
             setFullscreen(false);
         }
-        abandonAudioFocus();
+
+        if (abandonAudioFocus()) {
+            this.hasAudioFocus = false;
+        }
     }
 
     private void updateResumePosition() {
@@ -694,21 +702,27 @@ class ReactExoplayerView extends FrameLayout implements
 
     @Override
     public void onAudioFocusChange(int focusChange) {
+        String text = "onAudioFocusChange: focusChange=";
+
         switch (focusChange) {
             case AudioManager.AUDIOFOCUS_LOSS:
+                text += "loss";
                 this.hasAudioFocus = false;
                 eventEmitter.audioFocusChanged(false);
                 pausePlayback();
                 abandonAudioFocus();
                 break;
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
+                text += "loss_transient";
                 eventEmitter.audioFocusChanged(false);
                 break;
             case AudioManager.AUDIOFOCUS_GAIN:
+                text += "gain";
                 this.hasAudioFocus = true;
                 eventEmitter.audioFocusChanged(true);
                 break;
             default:
+                text += "unknown";
                 break;
         }
 
@@ -725,6 +739,8 @@ class ReactExoplayerView extends FrameLayout implements
                 }
             }
         }
+
+        Log.d(TAG, text + ', instance=' + hashCode());
     }
 
     // AudioBecomingNoisyListener implementation
@@ -781,7 +797,8 @@ class ReactExoplayerView extends FrameLayout implements
                 text += "unknown";
                 break;
         }
-        Log.d(TAG, text);
+
+        Log.d(TAG, text + ', instance=' + hashCode());
     }
 
     private void startProgressHandler() {
@@ -1366,23 +1383,23 @@ class ReactExoplayerView extends FrameLayout implements
 
     @Override
     public void onDrmKeysLoaded(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
-        Log.d("DRM Info", "onDrmKeysLoaded");
+        // Log.d("DRM Info", "onDrmKeysLoaded");
     }
 
     @Override
     public void onDrmSessionManagerError(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId, Exception e) {
-        Log.d("DRM Info", "onDrmSessionManagerError");
+        // Log.d("DRM Info", "onDrmSessionManagerError");
         eventEmitter.error("onDrmSessionManagerError", e);
     }
 
     @Override
     public void onDrmKeysRestored(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
-        Log.d("DRM Info", "onDrmKeysRestored");
+        // Log.d("DRM Info", "onDrmKeysRestored");
     }
 
     @Override
     public void onDrmKeysRemoved(int windowIndex, MediaSource.MediaPeriodId mediaPeriodId) {
-        Log.d("DRM Info", "onDrmKeysRemoved");
+        // Log.d("DRM Info", "onDrmKeysRemoved");
     }
 
     /**

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -586,6 +586,14 @@ class ReactExoplayerView extends FrameLayout implements
         return result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
     }
 
+    private boolean abandonAudioFocus() {
+        if (disableFocus || srcUri == null || !this.hasAudioFocus) {
+            return true;
+        }
+        int result = audioManager.abandonAudioFocus(this);
+        return result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;
+    }
+
     private void setPlayWhenReady(boolean playWhenReady) {
         if (player == null) {
             return;
@@ -644,7 +652,7 @@ class ReactExoplayerView extends FrameLayout implements
         if (isFullscreen) {
             setFullscreen(false);
         }
-        audioManager.abandonAudioFocus(this);
+        abandonAudioFocus();
     }
 
     private void updateResumePosition() {
@@ -691,7 +699,7 @@ class ReactExoplayerView extends FrameLayout implements
                 this.hasAudioFocus = false;
                 eventEmitter.audioFocusChanged(false);
                 pausePlayback();
-                audioManager.abandonAudioFocus(this);
+                abandonAudioFocus();
                 break;
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
                 eventEmitter.audioFocusChanged(false);


### PR DESCRIPTION
If disableFocus is set to true never change the audio focus via the audio manager. This introduces a wrapper around AudioManager.abandonAudioFocus() that checks the disableFocus flag. It mirrors the implementation of the requestAudioFocus() method which similarly wraps AudioManager.requestAudioFocus().