### PR TITLE
Set ExoPlayer volume on initialization

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -723,6 +723,21 @@ class ReactExoplayerView extends FrameLayout implements
         return DataSourceUtil.getDefaultHttpDataSourceFactory(this.themedReactContext, useBandwidthMeter ? bandwidthMeter : null, requestHeaders);
     }
 
+    private void setPlayerVolume(float volume) {
+        if (player == null || muted) {
+            return;
+        }
+
+        player.setVolume(volume);
+    }
+
+    private void mutePlayer() {
+        player.setVolume(0.0);
+    }
+
+    private void unmutePlayer() {
+        player.setVolume(audioVolume);
+    }
 
     // AudioManager.OnAudioFocusChangeListener implementation
 
@@ -748,15 +763,9 @@ class ReactExoplayerView extends FrameLayout implements
 
         if (player != null) {
             if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK) {
-                // Lower the volume
-                if (!muted) {
-                    player.setVolume(audioVolume * 0.8f);
-                }
+                setPlayerVolume(audioVolume * 0.8f); // Lower the volume
             } else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
-                // Raise it back to normal
-                if (!muted) {
-                    player.setVolume(audioVolume * 1);
-                }
+                setPlayerVolume(audioVolume * 1); // Raise it back to normal
             }
         }
     }
@@ -1127,15 +1136,19 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private void applyModifiers() {
+        Log.d("ReactExoplayerView", "applyModifiers() - repeat=" + repeat + ", muted=" + muted + ", volume=" + audioVolume);
         setRepeatModifier(repeat);
         setMutedModifier(muted);
+        setVolumeModifier(audioVolume);
     }
 
     public void setRepeatModifier(boolean repeat) {
         if (player != null) {
             if (repeat) {
+                Log.d("ReactExoplayerView", "setRepeatModifier() - setting repeat to REPEAT_MODE_ONE");
                 player.setRepeatMode(Player.REPEAT_MODE_ONE);
             } else {
+                Log.d("ReactExoplayerView", "setRepeatModifier() - setting repeat to REPEAT_MODE_OFF");
                 player.setRepeatMode(Player.REPEAT_MODE_OFF);
             }
         }
@@ -1289,18 +1302,19 @@ class ReactExoplayerView extends FrameLayout implements
         }
     }
 
-    public void setMutedModifier(boolean muted) {
-        this.muted = muted;
-        audioVolume = muted ? 0.f : 1.f;
+    public void setMutedModifier(boolean newMuted) {
+        muted = newMuted;
         if (player != null) {
-            player.setVolume(audioVolume);
+            Log.d("ReactExoplayerView", "setMutedModifier() - setting muted to" + muted + ", audioVolume is " + audioVolume);
+            muted ? mutePlayer() : unmutePlayer();
         }
     }
 
-    public void setVolumeModifier(float volume) {
-        audioVolume = volume;
+    public void setVolumeModifier(float newAudioVolume) {
+        audioVolume = newAudioVolume;
         if (player != null) {
-            player.setVolume(audioVolume);
+            Log.d("ReactExoplayerView", "setVolumeModifier() - setting audioVolume to " + audioVolume + ", muted is " + muted);
+            setPlayerVolume(audioVolume);
         }
     }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -724,6 +724,7 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private void setPlayerVolume(float volume) {
+        // If we're muted keep the volume at 0.0 (which will have been set by mutePlayer()).
         if (player == null || muted) {
             return;
         }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -437,23 +437,23 @@ class ReactExoplayerView extends FrameLayout implements
                     trackSelector = new DefaultTrackSelector(getContext(), videoTrackSelectionFactory);
                     trackSelector.setParameters(trackSelector.buildUponParameters().setMaxVideoBitrate(maxBitRate == 0 ? Integer.MAX_VALUE : maxBitRate));
 
-                    /*DefaultAllocator allocator = new DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE);
+                    DefaultAllocator allocator = new DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE);
                     DefaultLoadControl.Builder defaultLoadControlBuilder = new DefaultLoadControl.Builder();
                     defaultLoadControlBuilder.setAllocator(allocator);
                     defaultLoadControlBuilder.setBufferDurationsMs(minBufferMs, maxBufferMs, bufferForPlaybackMs, bufferForPlaybackAfterRebufferMs);
                     defaultLoadControlBuilder.setTargetBufferBytes(-1);
                     defaultLoadControlBuilder.setPrioritizeTimeOverSizeThresholds(true);
-                    DefaultLoadControl defaultLoadControl = defaultLoadControlBuilder.createDefaultLoadControl();*/
+                    DefaultLoadControl defaultLoadControl = defaultLoadControlBuilder.createDefaultLoadControl();
 
                     player = new SimpleExoPlayer.Builder(getContext(), renderersFactory)
                                 .setBandwidthMeter(bandwidthMeter)
                                 .setMediaSourceFactory(mediaSourceFactory)
                                 .setTrackSelector(trackSelector)
-                                // .setLoadControl(defaultLoadControl)
+                                .setLoadControl(defaultLoadControl)
                                 .build();
 
                     player.addListener(self);
-                    // player.addAnalyticsListener(new EventLogger(null));
+//                    player.addAnalyticsListener(new EventLogger(null));
                     player.addMetadataOutput(self);
                     exoPlayerView.setPlayer(player);
                     audioBecomingNoisyReceiver.setListener(self);
@@ -596,8 +596,8 @@ class ReactExoplayerView extends FrameLayout implements
     private void releasePlayer() {
         if (player != null) {
             updateResumePosition();
-            player.release();
             player.removeMetadataOutput(this);
+            player.release();
             trackSelector = null;
             player = null;
         }
@@ -825,7 +825,7 @@ class ReactExoplayerView extends FrameLayout implements
                 text += "unknown";
                 break;
         }
-        Log.d(TAG, text);
+//        Log.d(TAG, text);
     }
 
     private void startProgressHandler() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -733,7 +733,7 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private void mutePlayer() {
-        player.setVolume(0.0);
+        player.setVolume(0.0f);
     }
 
     private void unmutePlayer() {
@@ -1137,7 +1137,6 @@ class ReactExoplayerView extends FrameLayout implements
     }
 
     private void applyModifiers() {
-        Log.d("ReactExoplayerView", "applyModifiers() - repeat=" + repeat + ", muted=" + muted + ", volume=" + audioVolume);
         setRepeatModifier(repeat);
         setMutedModifier(muted);
         setVolumeModifier(audioVolume);
@@ -1146,10 +1145,8 @@ class ReactExoplayerView extends FrameLayout implements
     public void setRepeatModifier(boolean repeat) {
         if (player != null) {
             if (repeat) {
-                Log.d("ReactExoplayerView", "setRepeatModifier() - setting repeat to REPEAT_MODE_ONE");
                 player.setRepeatMode(Player.REPEAT_MODE_ONE);
             } else {
-                Log.d("ReactExoplayerView", "setRepeatModifier() - setting repeat to REPEAT_MODE_OFF");
                 player.setRepeatMode(Player.REPEAT_MODE_OFF);
             }
         }
@@ -1306,15 +1303,17 @@ class ReactExoplayerView extends FrameLayout implements
     public void setMutedModifier(boolean newMuted) {
         muted = newMuted;
         if (player != null) {
-            Log.d("ReactExoplayerView", "setMutedModifier() - setting muted to" + muted + ", audioVolume is " + audioVolume);
-            muted ? mutePlayer() : unmutePlayer();
+            if (muted) {
+                mutePlayer();
+            } else {
+                unmutePlayer();
+            }
         }
     }
 
     public void setVolumeModifier(float newAudioVolume) {
         audioVolume = newAudioVolume;
         if (player != null) {
-            Log.d("ReactExoplayerView", "setVolumeModifier() - setting audioVolume to " + audioVolume + ", muted is " + muted);
             setPlayerVolume(audioVolume);
         }
     }


### PR DESCRIPTION
We found that ExoPlayer wasn't respecting the initial volume set on the component. Updating the prop after initial load seems to work though. This PR should address that.

- Set the initial volume when ExoPlayer is initialized using the value provided to the component.
- Manage the `volume` and `mute` values separately. In other words, don't change the stored volume value when `mute` is set to true. Muting and unmuting should toggle the volume between 0.0 and the original value specified by the consumer of the `Video` component.
- Don't unmute the player if `volume` is > 0.0 but `muted` is still `true`.